### PR TITLE
Changes to facilitate pulling the KFS Account information out of the Xcomment field.

### DIFF
--- a/GiftModels/PremiumDetails.cs
+++ b/GiftModels/PremiumDetails.cs
@@ -38,7 +38,7 @@ namespace GiftModels
                 if (string.IsNullOrWhiteSpace(_premiumChart) && string.IsNullOrWhiteSpace(Xcomment))
                     return null;
                 if (string.IsNullOrWhiteSpace(_premiumChart))
-                    InitAccounDetails();
+                    InitAccountDetails();
 
                 return _premiumChart;
             }
@@ -57,7 +57,7 @@ namespace GiftModels
                 if (string.IsNullOrWhiteSpace(_premiumAccount) && string.IsNullOrWhiteSpace(Xcomment))
                     return null;
                 if (string.IsNullOrWhiteSpace(_premiumAccount))
-                    InitAccounDetails();
+                    InitAccountDetails();
 
                 return _premiumAccount;
             }
@@ -76,7 +76,7 @@ namespace GiftModels
                 if (string.IsNullOrWhiteSpace(_premiumSubAccount) && string.IsNullOrWhiteSpace(Xcomment))
                     return null;
                 if (string.IsNullOrWhiteSpace(_premiumAccount))
-                    InitAccounDetails();
+                    InitAccountDetails();
 
                 return _premiumSubAccount;
             }
@@ -91,7 +91,7 @@ namespace GiftModels
         /// <summary>
         /// Parse out the KFS chart, Account, and Sub-account (if present) from the XComment field. 
         /// </summary>
-        private void InitAccounDetails()
+        private void InitAccountDetails()
         {
             const string sPattern = @"\[\[(\w)-(\w{5,7})-?(\w{5})?\]\]";
             var result = System.Text.RegularExpressions.Regex.Match(Xcomment, sPattern);

--- a/GiftModels/PremiumDetails.cs
+++ b/GiftModels/PremiumDetails.cs
@@ -102,7 +102,7 @@ namespace GiftModels
             const string sPattern = @"\[\[(\w)-(\w{5,7})-?(\w{5})?\]\]";
             var result = System.Text.RegularExpressions.Regex.Match(Xcomment, sPattern);
 
-            if (result.Groups[1].Length > 0 && result.Groups[2].ToString().Length > 0)
+            if (result.Groups[1].ToString().Length > 0 && result.Groups[2].ToString().Length > 0)
             {
                 _premiumChart = result.Groups[1].ToString();
 

--- a/GiftModels/PremiumDetails.cs
+++ b/GiftModels/PremiumDetails.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 
 namespace GiftModels
 {
@@ -41,8 +37,9 @@ namespace GiftModels
             {
                 if (string.IsNullOrWhiteSpace(_premiumChart) && string.IsNullOrWhiteSpace(Xcomment))
                     return null;
-                if (string.IsNullOrWhiteSpace(_premiumChart) && Xcomment.Contains("-"))
-                    return Xcomment.Substring(0, Xcomment.IndexOf('-'));
+                if (string.IsNullOrWhiteSpace(_premiumChart))
+                    InitAccounDetails();
+
                 return _premiumChart;
             }
             set { _premiumChart = value; }
@@ -52,22 +49,66 @@ namespace GiftModels
         ///This is the KFS Account number used to credit the back the premium amount. 
         /// </summary>
         private string _premiumAccount;
+
         public string PremiumAccount
         {
             get
             {
                 if (string.IsNullOrWhiteSpace(_premiumAccount) && string.IsNullOrWhiteSpace(Xcomment))
                     return null;
-                if (string.IsNullOrWhiteSpace(_premiumAccount) && Xcomment.Contains("-"))
-                    return Xcomment.Substring(Xcomment.IndexOf('-') + 1);
+                if (string.IsNullOrWhiteSpace(_premiumAccount))
+                    InitAccounDetails();
+
                 return _premiumAccount;
             }
             set { _premiumAccount = value; }
         }
 
         /// <summary>
+        ///This is the KFS Sub-account number used to credit the back the premium amount. 
+        /// </summary>
+        private string _premiumSubAccount;
+
+        public string PremiumSubAccount
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(_premiumSubAccount) && string.IsNullOrWhiteSpace(Xcomment))
+                    return null;
+                if (string.IsNullOrWhiteSpace(_premiumAccount))
+                    InitAccounDetails();
+
+                return _premiumSubAccount;
+            }
+            set { _premiumSubAccount = value; }
+        }
+
+        /// <summary>
         /// This field is defaulted from the tms_premium table (W3). It is the monetary value associated with this premium. This value is normally the same amount as the value in the tms_premium table. 
         /// </summary>
         public decimal PremiumAmount { get; set; }
+
+        /// <summary>
+        /// Parse out the KFS chart, Account, and Sub-account (if present) from the XComment field. 
+        /// </summary>
+        private void InitAccounDetails()
+        {
+            const string sPattern = @"\[\[(\w)-(\w{5,7})-?(\w{5})?\]\]";
+            var result = System.Text.RegularExpressions.Regex.Match(Xcomment, sPattern);
+
+            if (result.Groups[1].Length > 0 && result.Groups[1].ToString().Length > 0)
+            {
+                _premiumChart = result.Groups[1].ToString();
+
+                _premiumAccount = result.Groups[2].ToString();
+
+                _premiumSubAccount = result.Groups[3].ToString();
+
+                if (string.IsNullOrWhiteSpace(_premiumSubAccount))
+                {
+                    _premiumSubAccount = "-----";
+                }
+            }
+        }
     }
 }

--- a/GiftModels/PremiumDetails.cs
+++ b/GiftModels/PremiumDetails.cs
@@ -38,7 +38,9 @@ namespace GiftModels
                 if (string.IsNullOrWhiteSpace(_premiumChart) && string.IsNullOrWhiteSpace(Xcomment))
                     return null;
                 if (string.IsNullOrWhiteSpace(_premiumChart))
+                {
                     InitAccountDetails();
+                }
 
                 return _premiumChart;
             }
@@ -57,7 +59,9 @@ namespace GiftModels
                 if (string.IsNullOrWhiteSpace(_premiumAccount) && string.IsNullOrWhiteSpace(Xcomment))
                     return null;
                 if (string.IsNullOrWhiteSpace(_premiumAccount))
+                {
                     InitAccountDetails();
+                }
 
                 return _premiumAccount;
             }
@@ -76,8 +80,10 @@ namespace GiftModels
                 if (string.IsNullOrWhiteSpace(_premiumSubAccount) && string.IsNullOrWhiteSpace(Xcomment))
                     return null;
                 if (string.IsNullOrWhiteSpace(_premiumAccount))
+                {
                     InitAccountDetails();
-
+                }
+                    
                 return _premiumSubAccount;
             }
             set { _premiumSubAccount = value; }

--- a/GiftModels/PremiumDetails.cs
+++ b/GiftModels/PremiumDetails.cs
@@ -96,7 +96,7 @@ namespace GiftModels
             const string sPattern = @"\[\[(\w)-(\w{5,7})-?(\w{5})?\]\]";
             var result = System.Text.RegularExpressions.Regex.Match(Xcomment, sPattern);
 
-            if (result.Groups[1].Length > 0 && result.Groups[1].ToString().Length > 0)
+            if (result.Groups[1].Length > 0 && result.Groups[2].ToString().Length > 0)
             {
                 _premiumChart = result.Groups[1].ToString();
 


### PR DESCRIPTION
@srkirkland ; @jpknoll ; @jSylvestre:
This will work.  Note that there will ALWAYS be a result.Groups array consisting of 4 elements because of the way the regex was defined; therefore, it is not necessary to do an Any() check; however, the length of the elements at pos'n 1 and 2 need to be checked to verify they are not blank.