### PR TITLE
Kjt addspacewhenremovingkfsaccountstring

### DIFF
--- a/GiftModels/PremiumDetails.cs
+++ b/GiftModels/PremiumDetails.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.CodeDom;
-using System.Linq;
 using System.Text;
 
 namespace GiftModels

--- a/GiftModels/PremiumDetails.cs
+++ b/GiftModels/PremiumDetails.cs
@@ -156,7 +156,7 @@ namespace GiftModels
                     sb.Append(' '); // Add a space after each segment.
                 }
                 // Lastly, remove the last, and final trailing space that was added above:
-                _commentOnly = sb.Remove(sb.Length - 1, 1).ToString();
+                _commentOnly = sb.ToString().Trim();
             }
         }
     }

--- a/GiftModels/PremiumDetails.cs
+++ b/GiftModels/PremiumDetails.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.CodeDom;
 using System.Linq;
+using System.Text;
 
 namespace GiftModels
 {
@@ -138,8 +140,26 @@ namespace GiftModels
                 }
             }
 
-            // left over after account info removed
-            _commentOnly = string.IsNullOrEmpty(_embeddedKfsAccountString) ? Comment : Comment.Replace(_embeddedKfsAccountString, "").Trim();
+            //Sample: Jacket[[3-WINKLER]]Aggies
+            _commentOnly = Comment;  // Set the _commentOnly to the same value as the Comment by default:
+            
+            // Check if there's embedded KFS Account details in the comment, and remove it from the remaining comments:
+            if (!string.IsNullOrEmpty(_embeddedKfsAccountString)) //, i.e., [[3-WINKLER]]
+            {
+                // Get the segments before and after the KFS Account details as applicable:
+                var segments = Comment.Split(new string[] {_embeddedKfsAccountString}, StringSplitOptions.RemoveEmptyEntries);
+                // , i.e., [Jacket, Aggies]
+                // But wait.  There may be spaces before or after each segment.  We'll need to remove these, 
+                // but add a space between segments as applicable:
+                var sb = new StringBuilder();
+                foreach (var segment in segments)
+                {
+                    sb.Append(segment.Trim()); // Remove any leading or trailing whitespace for each segment.
+                    sb.Append(' '); // Add a space after each segment.
+                }
+                // Lastly, remove the last, and final trailing space that was added above:
+                _commentOnly = sb.Remove(sb.Length - 1, 1).ToString();
+            }
         }
     }
 }


### PR DESCRIPTION
This will handle adding a space between the segments on either end of the embedded KFS Account data as needed when provided with a Comment like: "Jacket[[3-WINKLER]]Aggies".  It will return a _commentOnly like "Jacket Aggies" instead of "JacketAggies", which is more readable.